### PR TITLE
Allow proper compilation of .ts files in addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
     this.app = app;
-
+    this.setupPreprocessorRegistry('parent', app.registry);
   },
 
   blueprintsPath: function() {


### PR DESCRIPTION
Inspired by `ember-cli-babel` - https://github.com/babel/ember-cli-babel/blob/master/index.js#L61 which also has to take care of addons. Without that fix the compilation of addons is not done and the `ember-cli-typify` usage would be limited to apps only.